### PR TITLE
Remove unneccessary Promise polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "node_modules/.bin/mocha --recursive"
   },
   "dependencies": {
-    "bluebird": "^3.5.0",
     "chokidar": "^1.7.0",
     "death": "^1.1.0",
     "fs-extra": "^3.0.1"

--- a/test/queue_tests.js
+++ b/test/queue_tests.js
@@ -1,5 +1,4 @@
 const expect = require('chai').expect;
-const Promise = require('bluebird');
 const fs = require('fs-extra');
 const path = require('path');
 


### PR DESCRIPTION
Since this package targets Node 8+, a Promise polyfill is
not required. Node supports Promises natively since 6.11