### PR TITLE
Add the ability to set a priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ queue.publish(message);
 ```
 Publishes a new message to the job queue. Returns a promise that resolves when publishing is done
 - message - plain js object containing message data
-  - You can order messages by adding a `_priority` property to the message object. Messages will be consumed in order of priority, lowest first (1, 2, 3...). The default priority is "50".
+  - You can order messages by adding a `_priority` property to the message object (1 - 9). Messages will be consumed in order of priority, lowest first (1, 2, 3...). The default priority is "5". There is no assurance that a message with some priority will be processed fully before an other message with a lower priority, just that they will be read in order of priority.
 
 ### queue.consume
 ```js

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ queue.publish(message);
 ```
 Publishes a new message to the job queue. Returns a promise that resolves when publishing is done
 - message - plain js object containing message data
+  - You can order messages by adding a `_priority` property to the message object. Messages will be consumed in order of priority, lowest first (1, 2, 3...). The default priority is "50".
 
 ### queue.consume
 ```js

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ Creates a new instance of queuelite. Returns a promise that resolved to the queu
 
 ### queue.publish
 ```js
-queue.publish(message);
+queue.publish(message, options);
 ```
 Publishes a new message to the job queue. Returns a promise that resolves when publishing is done
-- message - plain js object containing message data
-  - You can order messages by adding a `_priority` property to the message object (1 - 9). Messages will be consumed in order of priority, lowest first (1, 2, 3...). The default priority is "5". There is no assurance that a message with some priority will be processed fully before an other message with a lower priority, just that they will be read in order of priority.
+- `message` - plain js object containing message data
+- `options` - (optional) plain js object containing extra options for processing the message
+  - `priority` - You can change the order that messages are being consumed by setting a priority between `1` and `9`. The default priority is `5`. There are no assurances that messages with some priority will be processed fully before an other messages with a lower priority, just that they will be read in order of priority.
 
 ### queue.consume
 ```js

--- a/lib/queuelite.js
+++ b/lib/queuelite.js
@@ -16,8 +16,14 @@ class Queuelite {
     this.storage = storage;
   }
 
-  async publish(data) {
-    await this.storage.storeMessage(data);
+  async publish(data, options) {
+    options = Object.assign({ priority: 5 }, options);
+
+    if (options.priority < 1 || options.priority > 9) {
+      throw new Error(`options.priority has to be between 1 and 9`);
+    }
+
+    await this.storage.storeMessage(data, options);
   }
 
   async consume(handler) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -42,7 +42,7 @@ class Storage {
     const nowNanoSeconds = seconds * 1e9 + nanoSeconds;
     const filePath = path.join(
       this.pendingDir,
-      `${options.priority}${nowNanoSeconds}`
+      `${options.priority}_${nowNanoSeconds}`
     );
 
     await fs.writeFile(filePath, JSON.stringify(message));

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -40,7 +40,8 @@ class Storage {
   async storeMessage(message) {
     const [seconds, nanoSeconds] = process.hrtime();
     const nowNanoSeconds = seconds * 1e9 + nanoSeconds;
-    const filePath = path.join(this.pendingDir, `${nowNanoSeconds}`);
+    const priority = message._priority || 50;
+    const filePath = path.join(this.pendingDir, `${priority}_${nowNanoSeconds}`);
 
     await fs.writeFile(filePath, JSON.stringify(message));
   }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -37,11 +37,13 @@ class Storage {
     }
   }
 
-  async storeMessage(message) {
+  async storeMessage(message, options) {
     const [seconds, nanoSeconds] = process.hrtime();
     const nowNanoSeconds = seconds * 1e9 + nanoSeconds;
-    const priority = message._priority || 50;
-    const filePath = path.join(this.pendingDir, `${priority}_${nowNanoSeconds}`);
+    const filePath = path.join(
+      this.pendingDir,
+      `${options.priority}${nowNanoSeconds}`
+    );
 
     await fs.writeFile(filePath, JSON.stringify(message));
   }

--- a/test/queue_tests.js
+++ b/test/queue_tests.js
@@ -8,10 +8,10 @@ const Queuelite = require('../lib/queuelite');
 const DATA_DIR = '/tmp/testDataDir';
 const DATA = { val: 1 };
 const DATA2 = { val: 2 };
-const DATA3 = { val: 3, _priority: 1 };
-const DATA4 = { val: 4, _priority: 3 };
-const DATA5 = { val: 5, _priority: 3 };
-const DATA6 = { val: 5, _priority: 60 };
+const DATA3 = { val: 3 };
+const DATA4 = { val: 4 };
+const DATA5 = { val: 5 };
+const DATA6 = { val: 6 };
 
 function consumeAndAssert(q, assertionFns) {
   let counter = 0;
@@ -75,20 +75,24 @@ describe('queuelite', () => {
     it('consumes messages in order of priority and time', async () => {
       const q = await Queuelite.connect(DATA_DIR);
 
-      await q.publish(DATA4); // priority 3 -> 2nd
-      await q.publish(DATA); // priority not set, defaults to 50 -> 4th
-      await q.publish(DATA6); // priority 60 -> 6th
-      await q.publish(DATA2); // priority not set, defaults to 50 -> 5th
-      await q.publish(DATA3); // priority 1 -> 1st
-      await q.publish(DATA5); // priority 3 -> 3rd
+      await q.publish(DATA5, { priority: 3 });
+      await q.publish(DATA);
+      await q.publish(DATA6, { priority: 6 });
+      await q.publish(DATA2);
+      await q.publish(DATA3, { priority: 1 });
+      await q.publish(DATA, { priority: 9 });
+      await q.publish(DATA4, { priority: 3 });
+      await q.publish(DATA6, { priority: 4 });
 
       await consumeAndAssert(q, [
-        msg => expect(msg).to.deep.equal(DATA3),
-        msg => expect(msg).to.deep.equal(DATA4),
-        msg => expect(msg).to.deep.equal(DATA5),
-        msg => expect(msg).to.deep.equal(DATA),
-        msg => expect(msg).to.deep.equal(DATA2),
-        msg => expect(msg).to.deep.equal(DATA6)
+        msg => expect(msg).to.deep.equal(DATA3), // 1
+        msg => expect(msg).to.deep.equal(DATA5), // 3
+        msg => expect(msg).to.deep.equal(DATA4), // 3
+        msg => expect(msg).to.deep.equal(DATA6), // 4
+        msg => expect(msg).to.deep.equal(DATA), // 5
+        msg => expect(msg).to.deep.equal(DATA2), // 5
+        msg => expect(msg).to.deep.equal(DATA6), // 6
+        msg => expect(msg).to.deep.equal(DATA) // 9
       ]);
     });
 
@@ -141,6 +145,19 @@ describe('queuelite', () => {
         (msg, metadata) => expect(metadata.tryCount).to.deep.equal(1),
         (msg, metadata) => expect(metadata.tryCount).to.deep.equal(0)
       ]);
+    });
+
+    it('throws an error for an invalid priority', async () => {
+      const q = await Queuelite.connect(DATA_DIR);
+      let error;
+
+      try {
+        await q.publish(DATA, { priority: 99 });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).to.be.an.instanceOf(Error);
     });
 
     it('aborts a message after reject with Queuelite.ABORT', async () => {


### PR DESCRIPTION
Thanks to the ordering of the file system, by prefixing the filename with a number, we get a priority functionality for (essentially) free.